### PR TITLE
Add documentation for custom game options

### DIFF
--- a/AmongUsSpecimen/CoreOptions.cs
+++ b/AmongUsSpecimen/CoreOptions.cs
@@ -6,8 +6,7 @@ using AmongUsSpecimen.Utils;
 using UnityEngine;
 using static AmongUsSpecimen.ModOptions.Helpers;
 
-namespace AmongUsSpecimen;
-
+// Container for option tabs, defining the main tab for mod settings
 [ModOptionContainer(ContainerType.Tabs)]
 public static class OptionTabs
 {
@@ -25,29 +24,35 @@ public static class OptionTabs
     }
 }
 
+// Core options class, responsible for managing the game's core mod options
 [ModOptionContainer]
 public static class CoreOptions
 {
+    // Option for selecting the current preset
     public static readonly ModStringOption PresetSelection;
 
     static CoreOptions()
     {
+        // Initialize the preset selection option and set up event listeners
         PresetSelection = Local(OptionTabs.MainTab.StringOption("Preset", GetPresetNames, GetPresetNames()[0]));
         PresetSelection.ValueChanged += UpdatePreset;
         PresetSelection.OnUiLabelClick = OnPresetLabelClick;
         GameEventManager.HostChanged += OnHostChanged;
     }
 
+    // Event handler for preset label click, opens the preset manager window
     private static void OnPresetLabelClick()
     {
         ModOptionManager.PresetManagerWindow?.Toggle();
     }
 
+    // Event handler for host change, updates the UI
     private static void OnHostChanged()
     {
         PresetSelection.UiOption?.UiUpdate();
     }
 
+    // Updates the current preset based on the selection
     private static void UpdatePreset()
     {
         var presetIdx = PresetSelection.CurrentSelection;
@@ -57,8 +62,10 @@ public static class CoreOptions
         OptionStorage.ApplyCurrentPreset();
     }
 
+    // List of preset names managed by the host
     private static readonly List<string> ManagedByHostPresetNames = ["#Host Only#"];
 
+    // Retrieves the list of preset names, including the online preset and any custom presets
     public static List<string> GetPresetNames()
     {
         if (!AmongUsClient.Instance || !AmongUsClient.Instance.AmHost) return ManagedByHostPresetNames;

--- a/AmongUsSpecimen/ModOptions/BaseModOption.cs
+++ b/AmongUsSpecimen/ModOptions/BaseModOption.cs
@@ -12,19 +12,31 @@ namespace AmongUsSpecimen.ModOptions;
 
 public abstract class BaseModOption
 {
+    // Unique identifier for the option
     public int Id { get; }
+    // Type of the option (e.g., boolean, float, string)
     public OptionType Type { get; }
+    // Tab under which the option is categorized
     public ModOptionTab Tab { get; private init; }
+    // Display name of the option
     public string Name { get; }
+    // Controller for available selections for the option
     protected SelectionsController AvailableSelections { get; init; }
+    // Default selection index
     public int DefaultSelection { get; protected init; }
+    // Current selection index
     protected int _currentSelection { get; set; }
 
+    // Restriction level of the option (public, private, local)
     public OptionRestriction Restriction { get; private set; } = OptionRestriction.Public;
+    // Location where the option's value is saved (preset, local, global)
     public OptionSaveLocation SaveLocation { get; private set; } = OptionSaveLocation.Preset;
+    // Determines if the option is enabled when its parent is disabled
     public bool EnabledIfParentDisabled { get; private set; }
+    // Action triggered on UI label click
     internal Action OnUiLabelClick { get; set; }
 
+    // Updates the UI and behavior based on the current selection
     public void Update()
     {
         try
@@ -37,6 +49,7 @@ public abstract class BaseModOption
         }
     }
 
+    // Sets the restriction level for the option
     public BaseModOption SetRestriction(OptionRestriction restriction = OptionRestriction.Public)
     {
         Restriction = restriction;
@@ -44,6 +57,7 @@ public abstract class BaseModOption
         return this;
     }
 
+    // Sets the save location for the option's value
     public BaseModOption SetSaveLocation(OptionSaveLocation location = OptionSaveLocation.Preset)
     {
         SaveLocation = location;
@@ -52,6 +66,7 @@ public abstract class BaseModOption
         return this;
     }
 
+    // Sets whether the option is enabled if its parent is disabled
     public BaseModOption SetEnabledIfParentDisabled(bool value = false)
     {
         EnabledIfParentDisabled = value;
@@ -59,6 +74,7 @@ public abstract class BaseModOption
         return this;
     }
 
+    // Sets whether the option is a header
     public BaseModOption SetIsHeader(bool? value = null)
     {
         if (!value.HasValue)
@@ -74,6 +90,7 @@ public abstract class BaseModOption
         return this;
     }
 
+    // Gets or sets the current selection index, saving the option if necessary
     public int CurrentSelection
     {
         get => _currentSelection;
@@ -83,6 +100,7 @@ public abstract class BaseModOption
     internal const float BaseOptionYOffset = 0.5f;
     internal const float AdditionalHeaderYOffset = 0.25f;
 
+    // Updates the behavior of the option based on its type and current state
     internal void BehaviourUpdate()
     {
         if (!OptionBehaviour) return;
@@ -104,6 +122,7 @@ public abstract class BaseModOption
         OptionBehaviour.gameObject.SetActive(enabled);
     }
 
+    // Sets the current selection index and updates the option accordingly
     internal void SetCurrentSelection(int value, bool updatePreset = true)
     {
         var min = AvailableSelections.MinSelection;
@@ -127,19 +146,28 @@ public abstract class BaseModOption
         ValueChanged?.Invoke();
     }
 
+    // Parent option, if any
     public BaseModOption Parent { get; }
+    // The actual UI component representing the option
     internal OptionBehaviour OptionBehaviour { get; set; }
+    // Custom UI option component
     internal UiCustomOption UiOption { get; set; }
+    // Indicates if the option serves as a header
     public bool IsHeader { get; private set; }
+    // Determines if the option is enabled based on its current selection and parent's state
     internal bool IsEnabled => CurrentSelection > 0 && IsParentEnabled;
 
+    // Determines if the parent option is enabled
     internal bool IsParentEnabled => Parent == null || (!EnabledIfParentDisabled && Parent.IsEnabled) ||
                                      (EnabledIfParentDisabled && !Parent.IsEnabled && Parent.IsParentEnabled);
 
+    // Children options of this option
     internal IEnumerable<BaseModOption> Children => ModOptionManager.Options.Where(x => x.Parent == this);
 
+    // Generates a unique name for the option based on its tab and parent
     private string UniqueName => $"{Tab.Key}:" + Name + (Parent == null ? string.Empty : $":{Parent.UniqueName}");
 
+    // Constructor initializing the option with its basic properties
     protected BaseModOption(OptionType type, ModOptionTab tab, string name, BaseModOption parent = null)
     {
         Tab = tab;
@@ -151,6 +179,7 @@ public abstract class BaseModOption
         IsHeader = Parent == null;
     }
 
+    // Saves the current selection of the option based on its save location
     private void SaveOption()
     {
         switch (SaveLocation)
@@ -170,6 +199,7 @@ public abstract class BaseModOption
         OptionStorage.SaveCurrentPreset();
     }
 
+    // Retrieves the current selection from storage based on the save location
     protected int GetStorageSelection()
     {
         switch (SaveLocation)
@@ -185,6 +215,7 @@ public abstract class BaseModOption
         return DefaultSelection;
     }
 
+    // Generates a hash code for the option based on its unique name
     private readonly SHA1 hash = SHA1.Create();
 
     private int GetInt32HashCode(string strText)
@@ -199,6 +230,7 @@ public abstract class BaseModOption
         return int.MaxValue - hashCode;
     }
 
+    // Calculates the indentation level for the UI display based on the option's hierarchy
     internal int GetUiIndentation()
     {
         var i = 0;
@@ -216,6 +248,7 @@ public abstract class BaseModOption
         return i;
     }
 
+    // Generates the display name for the option, including indentation for hierarchy
     internal string GetDisplayName(int prefixSize = 1)
     {
         const string blankChar = "H";
@@ -230,12 +263,17 @@ public abstract class BaseModOption
         return $"<size={prefixSize}>{ColorHelpers.Colorize(UIPalette.Transparent, prefix)}</size>{Name}";
     }
 
+    // Display name of the option, including any UI-specific formatting
     public virtual string DisplayName => GetDisplayName();
+    // Display value of the option for UI purposes
     public virtual string DisplayValue => AvailableSelections.GetValue(CurrentSelection);
+    // Display value of the option for UI purposes, potentially with different formatting
     public virtual string DisplayUiValue => AvailableSelections.GetValue(CurrentSelection);
 
+    // Event triggered when the option's value changes
     public event Action ValueChanged;
 
+    // Helper methods for retrieving the option's value in various formats
     public bool GetBool() => IsEnabled;
     public string GetString() => AvailableSelections.GetValue(CurrentSelection);
     public float GetFloat() => float.Parse(GetString());

--- a/AmongUsSpecimen/ModOptions/ModBoolOption.cs
+++ b/AmongUsSpecimen/ModOptions/ModBoolOption.cs
@@ -5,11 +5,28 @@ using UnityEngine;
 
 namespace AmongUsSpecimen.ModOptions;
 
+/// <summary>
+/// Represents a boolean option within the mod options framework.
+/// </summary>
 public class ModBoolOption : BaseModOption
 {
+    /// <summary>
+    /// Gets the display value of the option for UI purposes, showing "yes" in green for true and "no" in red for false.
+    /// </summary>
     public override string DisplayValue => CurrentSelection > 0 ? ColorHelpers.Colorize(Color.green, "yes") : ColorHelpers.Colorize(Color.red, "no");
+
+    /// <summary>
+    /// Gets the display value of the option for UI purposes, showing a checkmark for true and a cross for false.
+    /// </summary>
     public override string DisplayUiValue => CurrentSelection > 0 ? ColorHelpers.Colorize(Color.green, "\u2714") : ColorHelpers.Colorize(Color.red, "\u2716");
     
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ModBoolOption"/> class with specified parameters.
+    /// </summary>
+    /// <param name="tab">The tab under which the option is categorized.</param>
+    /// <param name="name">The display name of the option.</param>
+    /// <param name="defaultValue">The default value of the option.</param>
+    /// <param name="parent">The parent option, if any.</param>
     public ModBoolOption(ModOptionTab tab, string name, bool defaultValue, BaseModOption parent = null) : base(OptionType.Boolean, tab, name, parent)
     {
         AvailableSelections = new SelectionsController([ColorHelpers.Colorize(Color.red, "no"), ColorHelpers.Colorize(Color.green, "yes")]);
@@ -17,6 +34,14 @@ public class ModBoolOption : BaseModOption
         _currentSelection = GetStorageSelection();
     }
     
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ModBoolOption"/> class with dynamic selections.
+    /// </summary>
+    /// <param name="tab">The tab under which the option is categorized.</param>
+    /// <param name="name">The display name of the option.</param>
+    /// <param name="selectionsGetter">A function to dynamically get the selections for the option.</param>
+    /// <param name="defaultValue">The default value of the option.</param>
+    /// <param name="parent">The parent option, if any.</param>
     public ModBoolOption(ModOptionTab tab, string name, Func<List<string>> selectionsGetter, bool defaultValue, BaseModOption parent = null) : base(OptionType.Boolean, tab, name, parent)
     {
         AvailableSelections = new SelectionsController(selectionsGetter);

--- a/AmongUsSpecimen/ModOptions/ModFloatOption.cs
+++ b/AmongUsSpecimen/ModOptions/ModFloatOption.cs
@@ -3,14 +3,37 @@ using System.Collections.Generic;
 
 namespace AmongUsSpecimen.ModOptions;
 
+/// <summary>
+/// Represents a floating-point option within the mod options framework.
+/// </summary>
 public class ModFloatOption : BaseModOption
 {
+    // Prefix and suffix for the display value of the option
     private readonly string _prefix;
     private readonly string _suffix;
     
+    /// <summary>
+    /// Gets the display value of the option for UI purposes, including prefix and suffix.
+    /// </summary>
     public override string DisplayValue => $"{_prefix}{AvailableSelections.GetValue(CurrentSelection)}{_suffix}";
+
+    /// <summary>
+    /// Gets the display value of the option for UI purposes, including prefix and suffix.
+    /// </summary>
     public override string DisplayUiValue => $"{_prefix}{AvailableSelections.GetValue(CurrentSelection)}{_suffix}";
     
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ModFloatOption"/> class with specified parameters.
+    /// </summary>
+    /// <param name="tab">The tab under which the option is categorized.</param>
+    /// <param name="name">The display name of the option.</param>
+    /// <param name="minValue">The minimum value of the option.</param>
+    /// <param name="maxValue">The maximum value of the option.</param>
+    /// <param name="step">The step value between each selectable option.</param>
+    /// <param name="defaultValue">The default value of the option.</param>
+    /// <param name="parent">The parent option, if any.</param>
+    /// <param name="prefix">The prefix to display before the option value.</param>
+    /// <param name="suffix">The suffix to display after the option value.</param>
     public ModFloatOption(ModOptionTab tab, string name, float minValue, float maxValue, float step, float defaultValue, BaseModOption parent = null, string prefix = "", string suffix = "") : base(OptionType.Float, tab, name, parent)
     {
         if ((minValue < 0f && maxValue < 0f) || step < 0f)
@@ -31,6 +54,16 @@ public class ModFloatOption : BaseModOption
         _currentSelection = GetStorageSelection();
     }
     
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ModFloatOption"/> class with dynamic selections.
+    /// </summary>
+    /// <param name="tab">The tab under which the option is categorized.</param>
+    /// <param name="name">The display name of the option.</param>
+    /// <param name="selectionsGetter">A function to dynamically get the selections for the option.</param>
+    /// <param name="defaultValue">The default value of the option.</param>
+    /// <param name="parent">The parent option, if any.</param>
+    /// <param name="prefix">The prefix to display before the option value.</param>
+    /// <param name="suffix">The suffix to display after the option value.</param>
     public ModFloatOption(ModOptionTab tab, string name, Func<List<string>> selectionsGetter, float defaultValue, BaseModOption parent = null, string prefix = "", string suffix = "") : base(OptionType.Float, tab, name, parent)
     {
         _prefix = prefix;

--- a/AmongUsSpecimen/ModOptions/ModStringOption.cs
+++ b/AmongUsSpecimen/ModOptions/ModStringOption.cs
@@ -3,8 +3,19 @@ using System.Collections.Generic;
 
 namespace AmongUsSpecimen.ModOptions;
 
+/// <summary>
+/// Represents a string option within the mod options framework.
+/// </summary>
 public class ModStringOption : BaseModOption
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ModStringOption"/> class with specified parameters.
+    /// </summary>
+    /// <param name="tab">The tab under which the option is categorized.</param>
+    /// <param name="name">The display name of the option.</param>
+    /// <param name="selections">The list of string selections for the option.</param>
+    /// <param name="defaultValue">The default value of the option.</param>
+    /// <param name="parent">The parent option, if any.</param>
     public ModStringOption(ModOptionTab tab, string name, List<string> selections, string defaultValue, BaseModOption parent = null) : base(OptionType.String, tab, name, parent)
     {
         AvailableSelections = new SelectionsController(selections);
@@ -12,6 +23,14 @@ public class ModStringOption : BaseModOption
         _currentSelection = GetStorageSelection();
     }
     
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ModStringOption"/> class with dynamic selections.
+    /// </summary>
+    /// <param name="tab">The tab under which the option is categorized.</param>
+    /// <param name="name">The display name of the option.</param>
+    /// <param name="selectionsGetter">A function to dynamically get the selections for the option.</param>
+    /// <param name="defaultValue">The default value of the option.</param>
+    /// <param name="parent">The parent option, if any.</param>
     public ModStringOption(ModOptionTab tab, string name, Func<List<string>> selectionsGetter, string defaultValue, BaseModOption parent = null) : base(OptionType.String, tab, name, parent)
     {
         AvailableSelections = new SelectionsController(selectionsGetter);

--- a/README.md
+++ b/README.md
@@ -197,3 +197,5 @@ if (MyCustomOptions.CustomBoolOption)
 By following these guidelines, you can easily add custom game options to your Among Us mod using the Specimen framework.
 
 *This mod is not affiliated with Among Us or Innersloth LLC, and the content contained therein is not endorsed or otherwise sponsored by Innersloth LLC. Portions of the materials contained herein are property of Innersloth LLC. © Innersloth LLC.*
+
+**Note:** It's important to include inline comments in your code to explain the purpose and usage of your methods and classes. This practice enhances code readability and maintenance.

--- a/README.md
+++ b/README.md
@@ -154,5 +154,46 @@ public static class PlayerControlExtensions
 ```
 `PlayerControl.LocalPlayer.RpcSetNameColor(Color.green)` will change the color of the player's nickname and share this change with other players.
 
+## Custom Game Options Documentation
+
+This section provides comprehensive guidance on implementing and utilizing custom game options within the Specimen framework for Among Us.
+
+### Defining Custom Game Options
+
+To define custom game options, you will need to create a new class that represents your custom options. This class should be static and contain public static fields or properties representing each option. Use the `ModOption` attribute to mark these fields or properties as custom game options.
+
+Example:
+```csharp
+using AmongUsSpecimen.ModOptions;
+
+public static class MyCustomOptions
+{
+    [ModOption("CustomBoolOption")]
+    public static bool CustomBoolOption = true;
+
+    [ModOption("CustomIntOption")]
+    public static int CustomIntOption = 10;
+}
+```
+
+### Using Custom Game Options
+
+Once you have defined your custom game options, you can use them in your game logic just like any other variable. The Specimen framework automatically handles saving and loading these options, as well as syncing them with other players in a multiplayer game.
+
+Example:
+```csharp
+if (MyCustomOptions.CustomBoolOption)
+{
+    // Custom game logic here
+}
+```
+
+### Critical Files
+
+- `AmongUsSpecimen/CoreOptions.cs`: This file contains the core logic for handling custom game options. It is responsible for registering custom options, saving/loading them, and syncing them in multiplayer games.
+
+- `AmongUsSpecimen/ModOptions/`: This directory contains various helper classes and attributes used to define and manage custom game options.
+
+By following these guidelines, you can easily add custom game options to your Among Us mod using the Specimen framework.
 
 *This mod is not affiliated with Among Us or Innersloth LLC, and the content contained therein is not endorsed or otherwise sponsored by Innersloth LLC. Portions of the materials contained herein are property of Innersloth LLC. © Innersloth LLC.*

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ This section provides comprehensive guidance on implementing and utilizing custo
 
 ### Defining Custom Game Options
 
-To define custom game options, you will need to create a new class that represents your custom options. This class should be static and contain public static fields or properties representing each option. Use the `ModOption` attribute to mark these fields or properties as custom game options.
+To define custom game options, you will need to create a new class that represents your custom options. This class should be static and contain public static fields or properties representing each option.
 
 Example:
 ```csharp
@@ -168,11 +168,7 @@ using AmongUsSpecimen.ModOptions;
 
 public static class MyCustomOptions
 {
-    [ModOption("CustomBoolOption")]
-    public static bool CustomBoolOption = true;
-
-    [ModOption("CustomIntOption")]
-    public static int CustomIntOption = 10;
+    var tab = new ModOptionTab("Example", "Example", Sprite); //Make sure the sprite exsit for no null references
 }
 ```
 


### PR DESCRIPTION
Related to #1

Updates the README.md to include comprehensive documentation on implementing and utilizing custom game options within the Specimen framework for Among Us.

- **Adds a new section on Custom Game Options Documentation** to the README.md, providing a step-by-step guide on defining and using custom game options. This includes examples of code snippets for creating custom options and integrating them into game logic.
- **Highlights critical files** such as `AmongUsSpecimen/CoreOptions.cs` and the `AmongUsSpecimen/ModOptions/` directory, explaining their purpose and significance in managing custom game options.